### PR TITLE
Use TRAKT_TOKEN environment variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 *.pyc
 
 .venv*/
+.env

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Commands
       Merge duplicate history records
 
     Options:
-      --token TEXT            Trakt.tv authentication token. (default: prompt)
+      --token TEXT            Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)
       --backup-dir TEXT       Directory that backups should be stored in. (default: "./backups")
       --delta-max INTEGER     Maximum delta between history records to consider as duplicate (in seconds). (default: 600)
       --per-page INTEGER      Request page size. (default: 1000)
@@ -83,7 +83,7 @@ Commands
       Scan for duplicate history records
 
     Options:
-      --token TEXT         Trakt.tv authentication token. (default: prompt)
+      --token TEXT         Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)
       --delta-max INTEGER  Maximum delta between history records to consider as duplicate (in seconds). (default: 600)
       --per-page INTEGER   Request page size. (default: 1000)
       --help               Show this message and exit.
@@ -107,7 +107,7 @@ Commands
       BACKUP_ZIP is the location of the zip file created by the profile:history:backup command
 
     Options:
-      --token TEXT  Trakt.tv authentication token. (default: prompt)
+      --token TEXT  Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)
       --help        Show this message and exit.
 
 `````````````````````````````
@@ -121,7 +121,7 @@ Commands
       Create backup of a Trakt.tv profile
 
     Options:
-      --token TEXT        Trakt.tv authentication token. (default: prompt)
+      --token TEXT        Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)
       --backup-dir TEXT   Directory that backups should be stored in. (default: "./backups")
       --per-page INTEGER  Request page size. (default: 1000)
       --help              Show this message and exit.

--- a/trakt_tools/runner/commands/history/duplicates/merge.py
+++ b/trakt_tools/runner/commands/history/duplicates/merge.py
@@ -10,8 +10,8 @@ import os
 @click.command('history:duplicates:merge')
 @click.option(
     '--token',
-    default=None,
-    help='Trakt.tv authentication token. (default: prompt)'
+    default=os.environ.get('TRAKT_TOKEN') or None,
+    help='Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)'
 )
 @click.option(
     '--backup-dir',

--- a/trakt_tools/runner/commands/history/duplicates/scan.py
+++ b/trakt_tools/runner/commands/history/duplicates/scan.py
@@ -4,13 +4,14 @@ from trakt_tools.core.authentication import authenticate
 from trakt_tools.tasks import ScanHistoryDuplicatesTask
 
 import click
+import os
 
 
 @click.command('history:duplicates:scan')
 @click.option(
     '--token',
-    default=None,
-    help='Trakt.tv authentication token. (default: prompt)'
+    default=os.environ.get('TRAKT_TOKEN') or None,
+    help='Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)'
 )
 @click.option(
     '--delta-max',

--- a/trakt_tools/runner/commands/profile/backup/apply.py
+++ b/trakt_tools/runner/commands/profile/backup/apply.py
@@ -9,8 +9,8 @@ import os
 @click.argument('backup_zip', type=click.Path(exists=True))
 @click.option(
     '--token',
-    default=None,
-    help='Trakt.tv authentication token. (default: prompt)'
+    default=os.environ.get('TRAKT_TOKEN') or None,
+    help='Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)'
 )
 def profile_backup_apply(backup_zip, token):
     """Apply backup to a Trakt.tv profile.

--- a/trakt_tools/runner/commands/profile/backup/create.py
+++ b/trakt_tools/runner/commands/profile/backup/create.py
@@ -10,8 +10,8 @@ import os
 @click.command('profile:backup:create')
 @click.option(
     '--token',
-    default=None,
-    help='Trakt.tv authentication token. (default: prompt)'
+    default=os.environ.get('TRAKT_TOKEN') or None,
+    help='Trakt.tv authentication token. Overwrites TRAKT_TOKEN env var. (default: prompt)'
 )
 @click.option(
     '--backup-dir',


### PR DESCRIPTION
If `--token` isn't provided, use the `TRAKT_TOKEN` env var before prompting user for a pin