### PR TITLE
Deal with 429s on merge

### DIFF
--- a/trakt_tools/tasks/history/duplicates/merge/executor.py
+++ b/trakt_tools/tasks/history/duplicates/merge/executor.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import time
 
 from trakt_tools.core.input import boolean_input
 from ..core.formatter import Formatter
@@ -13,10 +12,9 @@ log = logging.getLogger(__name__)
 
 
 class Executor(object):
-    def __init__(self, review=True, batch_size=200, rate_limit=20):
+    def __init__(self, review=True, batch_size=200):
         self.review = review
         self.batch_size = batch_size
-        self.rate_limit = rate_limit
 
     def process_shows(self, profile, shows):
         log.debug('Executing actions on %d shows...', len(shows))

--- a/trakt_tools/tasks/history/duplicates/merge/main.py
+++ b/trakt_tools/tasks/history/duplicates/merge/main.py
@@ -106,7 +106,10 @@ class MergeHistoryDuplicatesTask(Task):
             review = boolean_input('Review every action?', default=True)
             print()
 
-        executor = Executor(review)
+        executor = Executor(
+            review,
+            rate_limit=self.rate_limit
+            )
 
         if not executor.process_shows(profile, self.scanner.shows):
             return False


### PR DESCRIPTION
I was getting lots of rate limit messages while trying to merge a bunch
of stuff on my account.

I was getting responses such as:
```
x-ratelimit: {"name":"AUTHED_API_POST_LIMIT","period":1,"limit":1,"remaining":0,"until":"2024-03-12T15:10:32Z"}
retry-after: 1
```

I added this retry logic which may be useful, but ultimately it
looks like the rate-limit that is set by the CLI should probably be used,
but is not currently used in the executor for the merge?
